### PR TITLE
chore(gitignore): add .worktrees/ + .claude/worktrees/ entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Worktree directories (org policy)
+.worktrees/
+.claude/worktrees/


### PR DESCRIPTION
Per worktree-gitignore-coverage audit (2026-04-26).

Prevents phantom-gitlinks pattern by ensuring both worktree directory patterns are properly ignored.

Ref: repos/docs/governance/worktree-gitignore-coverage-2026-04-26.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to ignore local worktree directories, with no runtime or production code changes.
> 
> **Overview**
> Adds `.worktrees/` and `.claude/worktrees/` to `.gitignore` to keep local git worktree directories out of version control and prevent accidental/phantom gitlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b81a86dee153468eeffbcbc0d08099754790ca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->