### PR TITLE
chore: normalize Taskfile tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,81 +7,48 @@ tasks:
       - task --list
 
   build:
-    desc: Build the Python package and docs shell when present
+    desc: Build the Python package
     cmds:
       - |
         set -euo pipefail
 
-        if [ -f pyproject.toml ]; then
-          if command -v uv >/dev/null 2>&1; then
-            uv build
-          else
-            python -m build
-          fi
-        fi
-
-        if [ -f package.json ] && grep -q '"docs:build"' package.json; then
-          if command -v bun >/dev/null 2>&1; then
-            bun run docs:build
-          else
-            echo "bun is required to build docs" >&2
-            exit 1
-          fi
+        if command -v uv >/dev/null 2>&1; then
+          uv build
+        else
+          python -m build
         fi
 
   test:
-    desc: Run the primary test suite for the detected stack
+    desc: Run the Python test suite
     cmds:
       - |
         set -euo pipefail
 
-        if [ -f pyproject.toml ]; then
-          if [ ! -d tests ] || ! find tests -type f -name "test_*.py" | grep -q .; then
-            echo "No test files found under tests/; skipping pytest."
-            exit 0
-          fi
-
-          if command -v uv >/dev/null 2>&1; then
-            uv run pytest
-          else
-            python -m pytest
-          fi
+        if [ ! -d tests ] || ! find tests -type f -name "test_*.py" | grep -q .; then
+          echo "No test files found under tests/; skipping pytest."
           exit 0
         fi
 
-        if [ -f package.json ] && grep -q '"test"' package.json; then
-          bun test
-          exit 0
+        if command -v uv >/dev/null 2>&1; then
+          uv run pytest
+        else
+          python -m pytest
         fi
-
-        echo "No supported test command found" >&2
-        exit 1
 
   lint:
-    desc: Run linting for the detected stack
+    desc: Run Python lint checks
     cmds:
       - |
         set -euo pipefail
 
-        if [ -f pyproject.toml ]; then
-          if command -v uv >/dev/null 2>&1; then
-            uv run ruff check .
-          else
-            python -m ruff check .
-          fi
-          exit 0
+        if command -v uv >/dev/null 2>&1; then
+          uv run ruff check .
+        else
+          python -m ruff check .
         fi
-
-        if [ -f package.json ] && grep -q '"lint"' package.json; then
-          bun run lint
-          exit 0
-        fi
-
-        echo "No supported lint command found" >&2
-        exit 1
 
   clean:
-    desc: Remove generated artifacts
+    desc: Remove Python build and cache artifacts
     cmds:
       - |
         set -euo pipefail

--- a/src/helios_bench/__init__.py
+++ b/src/helios_bench/__init__.py
@@ -20,21 +20,21 @@ Usage:
 """
 
 import argparse
-import subprocess
-import time
 import json
-import sys
-import os
 import statistics
-import psutil
-from datetime import datetime
-from pathlib import Path
-from typing import Dict, List, Any, Optional
-from dataclasses import dataclass, field, asdict
+import subprocess
+import sys
 import threading
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any
+
+import psutil
 
 # Import tasks
-from helios_bench.tasks import TASKS, BenchmarkTask, get_all_tasks, get_tasks_by_category
+from helios_bench.tasks import TASKS, BenchmarkTask, get_all_tasks
+
 
 @dataclass
 class ResourceStats:
@@ -56,7 +56,7 @@ class RunResult:
     resources: ResourceStats
     timestamp: str = ""
 
-@dataclass 
+@dataclass
 class BenchmarkResult:
     binary: str
     task_id: str
@@ -64,18 +64,18 @@ class BenchmarkResult:
     category: str
     difficulty: str
     runs: int
-    run_results: List[RunResult] = field(default_factory=list)
-    system_info: Dict[str, Any] = field(default_factory=dict)
+    run_results: list[RunResult] = field(default_factory=list)
+    system_info: dict[str, Any] = field(default_factory=dict)
     timestamp: str = ""
 
 class ResourceMonitor:
     def __init__(self, sample_interval: float = 0.1):
         self.sample_interval = sample_interval
-        self.samples: List[Dict] = []
+        self.samples: list[dict] = []
         self._running = False
-        self._thread: Optional[threading.Thread] = None
-        self._process: Optional[psutil.Process] = None
-    
+        self._thread: threading.Thread | None = None
+        self._process: psutil.Process | None = None
+
     def start(self, pid: int):
         self._running = True
         self.samples = []
@@ -85,13 +85,13 @@ class ResourceMonitor:
             self._thread.start()
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
-    
+
     def stop(self):
         self._running = False
         if self._thread:
             self._thread.join(timeout=1.0)
         return self.samples
-    
+
     def _monitor_loop(self):
         while self._running and self._process:
             try:
@@ -107,16 +107,16 @@ class ResourceMonitor:
                 time.sleep(self.sample_interval)
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 break
-    
+
     def aggregate(self) -> ResourceStats:
         if not self.samples:
             return ResourceStats()
-        
+
         rss = [s['rss_mb'] for s in self.samples if s.get('rss_mb', 0) > 0]
         cpu = [s['cpu_percent'] for s in self.samples if s.get('cpu_percent', 0) > 0]
         threads = [s['threads'] for s in self.samples if s.get('threads', 0) > 0]
         fds = [s['fds'] for s in self.samples if s.get('fds', 0) > 0]
-        
+
         return ResourceStats(
             rss_mean_mb=statistics.mean(rss) if rss else 0,
             rss_max_mb=max(rss) if rss else 0,
@@ -133,39 +133,39 @@ class LeakDetector:
     def __init__(self, runs: int = 10, warmup: int = 2):
         self.runs = runs
         self.warmup = warmup
-        self.results: List[Dict] = []
-    
-    def detect(self, binary: str, task: BenchmarkTask, profile: str = "proxy-minimax") -> Dict:
+        self.results: list[dict] = []
+
+    def detect(self, binary: str, task: BenchmarkTask, profile: str = "proxy-minimax") -> dict:
         print(f"  Warming up ({self.warmup} runs)...")
         for _ in range(self.warmup):
             self._run_single(binary, task, profile)
-        
+
         print(f"  Running {self.runs} measured runs...")
         for i in range(self.runs):
             result = self._run_single(binary, task, profile)
             self.results.append(result)
             print(f"    Run {i+1}: {result['elapsed']:.1f}s, RSS={result['rss_max_mb']:.0f}MB, FDs={result['fds_max']}")
-        
+
         return self._analyze_leaks()
-    
-    def _run_single(self, binary: str, task: BenchmarkTask, profile: str) -> Dict:
+
+    def _run_single(self, binary: str, task: BenchmarkTask, profile: str) -> dict:
         cmd = f"{binary} exec --profile {profile} --model minimax-m2.5 --skip-git-repo-check '{task.prompt}'"
-        
+
         monitor = ResourceMonitor(sample_interval=0.2)
         start = time.time()
-        
+
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         monitor.start(proc.pid)
-        
+
         try:
             proc.wait(timeout=task.timeout)
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
-        
+
         elapsed = time.time() - start
         stats = monitor.aggregate()
-        
+
         return {
             'elapsed': elapsed,
             'rss_mean_mb': stats.rss_mean_mb,
@@ -173,22 +173,22 @@ class LeakDetector:
             'cpu_mean': stats.cpu_mean_percent,
             'fds_max': stats.fds_max,
         }
-    
-    def _analyze_leaks(self) -> Dict:
+
+    def _analyze_leaks(self) -> dict:
         rss_vals = [r['rss_max_mb'] for r in self.results]
         fds_vals = [r['fds_max'] for r in self.results]
-        
+
         rss_trend = self._calc_trend(rss_vals)
         fds_trend = self._calc_trend(fds_vals)
-        
+
         return {
             'runs': self.runs,
             'memory': {'values': rss_vals, 'trend': rss_trend, 'leak': abs(rss_trend) > 0.1},
             'file_descriptors': {'values': fds_vals, 'trend': fds_trend, 'leak': abs(fds_trend) > 0.1},
             'healthy': abs(rss_trend) <= 0.1 and abs(fds_trend) <= 0.1,
         }
-    
-    def _calc_trend(self, values: List[float]) -> float:
+
+    def _calc_trend(self, values: list[float]) -> float:
         if len(values) < 2:
             return 0.0
         n = len(values)
@@ -207,16 +207,16 @@ class BenchmarkRunner:
             'memory_total_gb': psutil.virtual_memory().total / (1024**3),
             'platform': sys.platform,
         }
-    
+
     def run_task(self, task: BenchmarkTask) -> RunResult:
         cmd = f"{self.binary} exec --profile {self.profile} --model minimax-m2.5 --skip-git-repo-check '{task.prompt}'"
-        
+
         monitor = ResourceMonitor(sample_interval=0.1)
         start = time.time()
-        
+
         proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         monitor.start(proc.pid)
-        
+
         try:
             proc.wait(timeout=task.timeout)
             success = proc.returncode == 0
@@ -224,10 +224,10 @@ class BenchmarkRunner:
             proc.kill()
             proc.wait()
             success = False
-        
+
         elapsed = time.time() - start
         stats = monitor.aggregate()
-        
+
         return RunResult(
             run_id=1,
             elapsed_seconds=elapsed,
@@ -235,17 +235,17 @@ class BenchmarkRunner:
             resources=stats,
             timestamp=datetime.now().isoformat(),
         )
-    
+
     def run_benchmark(self, task: BenchmarkTask, runs: int = 5) -> BenchmarkResult:
         results = []
-        
+
         for i in range(runs):
             print(f"  Run {i+1}/{runs}...", end=" ")
             result = self.run_task(task)
             result.run_id = i + 1
             results.append(result)
             print(f"{result.elapsed_seconds:.2f}s, RSS={result.resources.rss_max_mb:.0f}MB, FDs={result.resources.fds_max}")
-        
+
         return BenchmarkResult(
             binary=self.binary,
             task_id=task.id,
@@ -257,18 +257,18 @@ class BenchmarkRunner:
             system_info=self.system_info,
             timestamp=datetime.now().isoformat(),
         )
-    
-    def compare(self, other_binary: str, task: BenchmarkTask, runs: int = 3) -> Dict:
+
+    def compare(self, other_binary: str, task: BenchmarkTask, runs: int = 3) -> dict:
         print(f"A: {self.binary}")
         result_a = self.run_benchmark(task, runs)
-        
+
         print(f"\nB: {other_binary}")
         runner_b = BenchmarkRunner(other_binary, self.profile)
         result_b = runner_b.run_benchmark(task, runs)
-        
+
         return self._compare_results(result_a, result_b)
-    
-    def _compare_results(self, a: BenchmarkResult, b: BenchmarkResult) -> Dict:
+
+    def _compare_results(self, a: BenchmarkResult, b: BenchmarkResult) -> dict:
         def metrics(r: BenchmarkResult):
             elapsed = [rr.elapsed_seconds for rr in r.run_results]
             rss = [rr.resources.rss_max_mb for rr in r.run_results]
@@ -278,10 +278,10 @@ class BenchmarkRunner:
                 'rss_mean': statistics.mean(rss),
                 'rss_max': max(rss),
             }
-        
+
         ma = metrics(a)
         mb = metrics(b)
-        
+
         return {
             'task': a.task_id,
             'binary_a': a.binary,
@@ -295,13 +295,13 @@ class BenchmarkRunner:
 def main():
     parser = argparse.ArgumentParser(description="Helios Benchmark Harness")
     subparsers = parser.add_subparsers(dest='command')
-    
+
     # Tasks
     tasks_parser = subparsers.add_parser('tasks', help='List tasks')
     tasks_parser.add_argument('--category', help='Filter by category')
     tasks_parser.add_argument('--difficulty', help='Filter by difficulty')
     tasks_parser.add_argument('--list', action='store_true', help='List all tasks')
-    
+
     # Run
     run_parser = subparsers.add_parser('run', help='Run benchmark')
     run_parser.add_argument('--binary', required=True)
@@ -309,7 +309,7 @@ def main():
     run_parser.add_argument('--runs', type=int, default=5)
     run_parser.add_argument('--profile', default='proxy-minimax')
     run_parser.add_argument('--output')
-    
+
     # Compare
     compare_parser = subparsers.add_parser('compare', help='Compare binaries')
     compare_parser.add_argument('--binary-a', required=True)
@@ -318,7 +318,7 @@ def main():
     compare_parser.add_argument('--runs', type=int, default=3)
     compare_parser.add_argument('--profile', default='proxy-minimax')
     compare_parser.add_argument('--output')
-    
+
     # Leak
     leak_parser = subparsers.add_parser('leak', help='Leak detection')
     leak_parser.add_argument('--binary', required=True)
@@ -327,29 +327,29 @@ def main():
     leak_parser.add_argument('--warmup', type=int, default=2)
     leak_parser.add_argument('--profile', default='proxy-minimax')
     leak_parser.add_argument('--output')
-    
+
     args = parser.parse_args()
-    
+
     if args.command == 'tasks':
         tasks = get_all_tasks()
         if args.category:
             tasks = [t for t in tasks if t.category == args.category]
         if args.difficulty:
             tasks = [t for t in tasks if t.difficulty == args.difficulty]
-        
+
         print(f"=== Helios Benchmark Tasks ({len(tasks)}) ===")
         print(f"\n{'ID':<20} {'Name':<25} {'Category':<20} {'Difficulty'}")
         print("-" * 80)
         for t in tasks:
             print(f"{t.id:<20} {t.name:<25} {t.category:<20} {t.difficulty}")
         return
-    
+
     if args.command == 'run':
         task = TASKS[args.task]
         print(f"Running benchmark: {task.name} ({task.category})")
         runner = BenchmarkRunner(args.binary, args.profile)
         result = runner.run_benchmark(task, args.runs)
-        
+
         output = asdict(result)
         if args.output:
             with open(args.output, 'w') as f:
@@ -357,26 +357,26 @@ def main():
             print(f"\nSaved to: {args.output}")
         else:
             print(json.dumps(output, indent=2, default=str))
-    
+
     elif args.command == 'compare':
         task = TASKS[args.task]
         print(f"Comparing: {task.name}")
         runner = BenchmarkRunner(args.binary_a, args.profile)
         comparison = runner.compare(args.binary_b, task, args.runs)
-        
+
         if args.output:
             with open(args.output, 'w') as f:
                 json.dump(comparison, f, indent=2)
             print(f"\nSaved to: {args.output}")
         else:
             print(json.dumps(comparison, indent=2))
-    
+
     elif args.command == 'leak':
         task = TASKS[args.task]
         print(f"Leak detection: {task.name}")
         detector = LeakDetector(runs=args.runs, warmup=args.warmup)
         result = detector.detect(args.binary, task, args.profile)
-        
+
         if args.output:
             with open(args.output, 'w') as f:
                 json.dump(result, f, indent=2)

--- a/src/helios_bench/cli.py
+++ b/src/helios_bench/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 from helios_bench import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/helios_bench/tasks.py
+++ b/src/helios_bench/tasks.py
@@ -4,7 +4,7 @@ Helios Benchmark Tasks - Terminal Bench Style
 
 Based on Terminal-Bench 2.0 categories:
 - Code Completion
-- Code Review  
+- Code Review
 - Refactoring
 - Debugging
 - Test Generation
@@ -12,9 +12,9 @@ Based on Terminal-Bench 2.0 categories:
 - System Administration
 """
 
-from dataclasses import dataclass
-from typing import Dict, List, Optional
 import json
+from dataclasses import dataclass
+
 
 @dataclass
 class BenchmarkTask:
@@ -23,12 +23,12 @@ class BenchmarkTask:
     category: str
     difficulty: str  # easy, medium, hard
     prompt: str
-    expected_output: Optional[str] = None
+    expected_output: str | None = None
     timeout: int = 30
     max_tokens: int = 100
 
 # Terminal-Bench style tasks
-TASKS: Dict[str, BenchmarkTask] = {
+TASKS: dict[str, BenchmarkTask] = {
     # CODE COMPLETION (easy)
     "palindrome": BenchmarkTask(
         id="palindrome",
@@ -39,10 +39,10 @@ TASKS: Dict[str, BenchmarkTask] = {
         timeout=20,
         max_tokens=50,
     ),
-    
+
     # CODE COMPLETION (medium)
     "fibonacci": BenchmarkTask(
-        id="fibonacci", 
+        id="fibonacci",
         name="Fibonacci Sequence",
         category="code_completion",
         difficulty="medium",
@@ -50,12 +50,12 @@ TASKS: Dict[str, BenchmarkTask] = {
         timeout=25,
         max_tokens=80,
     ),
-    
+
     # CODE REVIEW (medium)
     "buggy_add": BenchmarkTask(
         id="buggy_add",
         name="Review Buggy Code",
-        category="code_review", 
+        category="code_review",
         difficulty="easy",
         prompt="""Review this Python code for bugs:
 
@@ -70,7 +70,7 @@ print(calculate_average([]))
         timeout=20,
         max_tokens=100,
     ),
-    
+
     # REFACTORING (medium)
     "refactor_loop": BenchmarkTask(
         id="refactor_loop",
@@ -90,7 +90,7 @@ def get_positive(numbers):
         timeout=20,
         max_tokens=50,
     ),
-    
+
     # DEBUGGING (medium)
     "debug_division": BenchmarkTask(
         id="debug_division",
@@ -108,7 +108,7 @@ print(safe_divide(10, 0))
         timeout=20,
         max_tokens=50,
     ),
-    
+
     # TEST GENERATION (medium)
     "write_tests": BenchmarkTask(
         id="write_tests",
@@ -124,7 +124,7 @@ def validate_email(email: str) -> bool:
         timeout=30,
         max_tokens=150,
     ),
-    
+
     # SCIENTIFIC COMPUTING (hard)
     "bayesian_sampler": BenchmarkTask(
         id="bayesian_sampler",
@@ -140,7 +140,7 @@ def validate_email(email: str) -> bool:
         timeout=45,
         max_tokens=200,
     ),
-    
+
     # SYSTEM ADMIN (medium)
     "log_parser": BenchmarkTask(
         id="log_parser",
@@ -162,13 +162,13 @@ Print only the ERROR lines.""",
 def get_task(task_id: str) -> BenchmarkTask:
     return TASKS.get(task_id, TASKS["palindrome"])
 
-def get_tasks_by_category(category: str) -> List[BenchmarkTask]:
+def get_tasks_by_category(category: str) -> list[BenchmarkTask]:
     return [t for t in TASKS.values() if t.category == category]
 
-def get_tasks_by_difficulty(difficulty: str) -> List[BenchmarkTask]:
+def get_tasks_by_difficulty(difficulty: str) -> list[BenchmarkTask]:
     return [t for t in TASKS.values() if t.difficulty == difficulty]
 
-def get_all_tasks() -> List[BenchmarkTask]:
+def get_all_tasks() -> list[BenchmarkTask]:
     return list(TASKS.values())
 
 def export_tasks_json() -> str:


### PR DESCRIPTION
Detected heliosBench as a Python package and narrowed the Taskfile build, test, lint, and clean tasks to that stack. Also applied Ruff-safe source cleanup so the new lint task passes locally.

Validation:
- task build
- task test
- task lint

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/lint task wiring and non-functional Python formatting/typing changes only; no runtime behavior changes beyond Taskfile command selection.
> 
> **Overview**
> Simplifies `Taskfile.yml` to **Python-only** `build`/`test`/`lint`/`clean` tasks, removing stack autodetection plus JS/docs build and test paths; `test` now skips cleanly when no `tests/test_*.py` exist.
> 
> Applies Ruff-safe cleanup in `src/helios_bench` by normalizing formatting, removing unused imports/exports (e.g., `get_tasks_by_category` import), and updating type hints to modern built-in generics/union syntax; `cli.py` also standardizes the `__main__` guard quoting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b503a0292b74467996323552fd5d042010626d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->