### PR TITLE
chore: add standard issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,3 @@ A clear description of what you expected to happen.
 **Environment:**
  - OS: [e.g. macOS, Linux]
  - Version [e.g. 0.1.0]
-
-**Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: 🐛 Bug report
+description: Report something that isn't working
+labels: bug
+title: "[Bug]: "
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1.
+2.
+3.
+
+**Expected behavior**
+A clear description of what you expected to happen.
+
+**Environment:**
+ - OS: [e.g. macOS, Linux]
+ - Version [e.g. 0.1.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,6 +13,3 @@ A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
-
-**Additional context**
-Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: 🚀 Feature request
+description: Suggest a new feature or improvement
+labels: enhancement
+title: "[Feature]: "
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.


### PR DESCRIPTION
Adds standard markdown issue templates for bug reports and feature requests.\n\n:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds GitHub metadata files and does not affect runtime code paths or data handling.
> 
> **Overview**
> Adds GitHub issue templates for **bug reports** and **feature requests** under `.github/ISSUE_TEMPLATE`, including default titles, labels (`bug`/`enhancement`), and structured prompts to standardize incoming issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c636996170523fdf28450c026700654b8fbbba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->